### PR TITLE
ANS-38 Improve lookup.js: Enhance input sanitisation, capabilities normalisation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ Desktop.ini
 # Other temporary files
 *.tmp
 *.bak
+*.fix.js
 
 # Logs
 logs


### PR DESCRIPTION
... and pagination consistency

Filter out empty/null/undefined params for robustness. Normalize capabilities to support strings, arrays, and comma-separated values with trimming/filtering. Remove redundant string split in capabilities handling. Default limit to 10 on invalid inputs and fix next_page_token comparison to use actualLimit. Maintain in-memory AND filtering for capabilities and policy compatibility checks.